### PR TITLE
Add better markup to login, forgot password form rendering

### DIFF
--- a/forgot_pass_class.php
+++ b/forgot_pass_class.php
@@ -15,10 +15,10 @@ class afo_forgot_pass_class {
 			<div class="login_wid forgot_pass">
 				<p class="login_form_group login_wid_password">
 					<label for="user_email"><?php _e('Email','lwa');?></label>
-					<input type="email" name="user_username" id="user_email" required="required"/>
+					<input type="email" name="user_username" id="user_email" required="required" placeholder="Email Address" />
 				</p>
 				<p class="login_wid_submit">
-					<input name="forgot" type="submit" value="<?php _e('Submit','lwa');?>" /></li>
+					<button name="forgot"><?php _e('Submit','lwa');?></button>
 				</p>
 				<p class="forgot-text">
 					<?php _e('Please enter your email. The password reset link will be provided in your email.','lwa');?>

--- a/forgot_pass_class.php
+++ b/forgot_pass_class.php
@@ -14,8 +14,8 @@ class afo_forgot_pass_class {
 		<input type="hidden" name="option" value="afo_forgot_pass" />
 			<div class="login_wid forgot_pass">
 				<p class="login_form_group login_wid_password">
-					<label for="user_username"><?php _e('Email','lwa');?></label>
-					<input type="email" name="user_username" required="required"/>
+					<label for="user_email"><?php _e('Email','lwa');?></label>
+					<input type="email" name="user_username" id="user_email" required="required"/>
 				</p>
 				<p class="login_wid_submit">
 					<input name="forgot" type="submit" value="<?php _e('Submit','lwa');?>" /></li>

--- a/forgot_pass_class.php
+++ b/forgot_pass_class.php
@@ -1,61 +1,67 @@
 <?php
 
 class afo_forgot_pass_class {
-	
+
 	public function ForgotPassForm(){
 		if(!session_id()){
 			@session_start();
 		}
-		
+
 		$this->error_message();
 		if(!is_user_logged_in()){
 		?>
 		<form name="forgot" id="forgot" method="post" action="">
 		<input type="hidden" name="option" value="afo_forgot_pass" />
-			<ul class="login_wid forgot_pass">
-				<li><?php _e('Email','lwa');?></li>
-				<li><input type="text" name="user_username" required="required"/></li>
-				<li><input name="forgot" type="submit" value="<?php _e('Submit','lwa');?>" /></li>
-				<li class="forgot-text"><?php _e('Please enter your email. The password reset link will be provided in your email.','lwa');?></li>
-			</ul>
+			<div class="login_wid forgot_pass">
+				<p class="login_form_group login_wid_password">
+					<label for="user_username"><?php _e('Email','lwa');?></label>
+					<input type="email" name="user_username" required="required"/>
+				</p>
+				<p class="login_wid_submit">
+					<input name="forgot" type="submit" value="<?php _e('Submit','lwa');?>" /></li>
+				</p>
+				<p class="forgot-text">
+					<?php _e('Please enter your email. The password reset link will be provided in your email.','lwa');?>
+				</p>
+			</div>
 		</form>
-		<?php 
+		<?php
 		}
 	}
-	
+
 	public function message_close_button(){
 		$cb = '<a href="javascript:void(0);" onclick="closeMessage();" class="close_button_afo">x</a>';
 		return $cb;
 	}
-	
+
 	public function error_message(){
 		if(!session_id()){
 			@session_start();
 		}
-		
+
 		if($_SESSION['msg']){
 			echo '<div class="'.$_SESSION['msg_class'].'">'.$_SESSION['msg'].$this->message_close_button().'</div>';
 			unset($_SESSION['msg']);
 			unset($_SESSION['msg_class']);
 		}
 	}
-} 
+}
 
 
 function forgot_pass_validate(){
 	if(!session_id()){
 		@session_start();
 	}
-	
+
 	if(isset($_GET['key']) && $_GET['action'] == "reset_pwd") {
 		global $wpdb;
 		$reset_key = $_GET['key'];
 		$user_login = $_GET['login'];
 		$user_data = $wpdb->get_row($wpdb->prepare("SELECT ID, user_login, user_email FROM $wpdb->users WHERE user_activation_key = %s AND user_login = %s", $reset_key, $user_login));
-		
+
 		$user_login = $user_data->user_login;
 		$user_email = $user_data->user_email;
-		
+
 		if(!empty($reset_key) && !empty($user_data)) {
 			$new_password = wp_generate_password(7, false);
 				wp_set_password( $new_password, $user_data->ID );
@@ -66,7 +72,7 @@ function forgot_pass_validate(){
 			$message .= sprintf(__('Username: %s'), $user_login) . "\r\n\r\n";
 			$message .= sprintf(__('Password: %s'), $new_password) . "\r\n\r\n";
 			$message .= __('You can now login with your new password at: ','lwa') . site_url() . "\r\n\r\n";
-			
+
 			if ( $message && !wp_mail($user_email, 'Password Reset Request', $message, $headers) ) {
 				wp_die('Email failed to send for some unknown reason');
 				exit;
@@ -75,7 +81,7 @@ function forgot_pass_validate(){
 				wp_die('New Password successfully sent to your mail address.');
 				exit;
 			}
-		} 
+		}
 		else {
 			wp_die('Not a Valid Key.');
 			exit;
@@ -83,32 +89,32 @@ function forgot_pass_validate(){
 }
 
 	if(isset($_POST['option']) and $_POST['option'] == "afo_forgot_pass"){
-	
+
 		global $wpdb;
 		$msg = '';
 		if(empty($_POST['user_username'])) {
 			$_SESSION['msg_class'] = 'error_wid_login';
 			$msg .= __('Email is empty!','lwa');
 		}
-		
+
 		$user_username = $wpdb->escape(trim($_POST['user_username']));
-		
+
 		$user_data = get_user_by('email', $user_username);
-		if(empty($user_data)) { 
+		if(empty($user_data)) {
 			$_SESSION['msg_class'] = 'error_wid_login';
 			$msg .= __('Invalid E-mail address!','lwa');
 		}
-		
+
 		$user_login = $user_data->data->user_login;
 		$user_email = $user_data->data->user_email;
-		
+
 		if($user_email){
 			$key = $wpdb->get_var($wpdb->prepare("SELECT user_activation_key FROM $wpdb->users WHERE user_login = %s", $user_login));
 			if(empty($key)) {
 				$key = wp_generate_password(10, false);
-				$wpdb->update($wpdb->users, array('user_activation_key' => $key), array('user_login' => $user_login));	
+				$wpdb->update($wpdb->users, array('user_activation_key' => $key), array('user_login' => $user_login));
 			}
-			
+
 			//mailing reset details to the user
 			$headers = 'From: '.get_bloginfo('name').' <no-reply@wordpress.com>' . "\r\n";
 			$message = __('Someone requested that the password be reset for the following account:','lwa') . "\r\n\r\n";
@@ -117,7 +123,7 @@ function forgot_pass_validate(){
 			$message .= __('If this was a mistake, just ignore this email and nothing will happen.','lwa') . "\r\n\r\n";
 			$message .= __('To reset your password, visit the following address:','lwa') . "\r\n\r\n";
 			$message .= site_url() . "?action=reset_pwd&key=$key&login=" . rawurlencode($user_login) . "\r\n";
-			
+
 			if ( !wp_mail($user_email, 'Password Reset Request', $message, $headers) ) {
 				$_SESSION['msg_class'] = 'error_wid_login';
 				$_SESSION['msg'] = __('Email failed to send for some unknown reason.','lwa');
@@ -132,7 +138,7 @@ function forgot_pass_validate(){
 		}
 	}
 }
-	
+
 
 add_action( 'init', 'forgot_pass_validate' );
 ?>

--- a/login_afo_widget.php
+++ b/login_afo_widget.php
@@ -108,11 +108,11 @@ class login_wid extends WP_Widget {
 			<div class="login_wid">
 				<p class="login_form_group login_wid_username">
 					<label for="user_username"><?php _e('Username','lwa');?></label>
-					<input type="text" name="user_username" required="required" placeholder="Username"/>
+					<input type="text" name="user_username" id="user_username" required="required" placeholder="Username"/>
 				</p>
 				<p class="login_form_group login_wid_password">
-					<label for="user_username"><?php _e('Password','lwa');?></label>
-					<input type="password" name="user_password" required="required" placeholder="Password"/>
+					<label for="user_password"><?php _e('Password','lwa');?></label>
+					<input type="password" name="user_password" id="user_password" required="required" placeholder="Password"/>
 				</p>
 			<?php $this->add_remember_me();?>
 			<p class="login_wid_submit">

--- a/login_afo_widget.php
+++ b/login_afo_widget.php
@@ -1,7 +1,7 @@
 <?php
 
 class login_wid extends WP_Widget {
-	
+
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_plugin_styles' ) );
 		add_action( 'wp_head', array( $this, 'custom_styles_afo' ) );
@@ -14,9 +14,9 @@ class login_wid extends WP_Widget {
 
 	public function widget( $args, $instance ) {
 		extract( $args );
-		
+
 		$wid_title = apply_filters( 'widget_title', $instance['wid_title'] );
-		
+
 		echo $args['before_widget'];
 		if ( ! empty( $wid_title ) )
 			echo $args['before_title'] . $wid_title . $args['after_title'];
@@ -38,33 +38,33 @@ class login_wid extends WP_Widget {
 		<p><label for="<?php echo $this->get_field_id('wid_title'); ?>"><?php _e('Title:'); ?> </label>
 		<input class="widefat" id="<?php echo $this->get_field_id('wid_title'); ?>" name="<?php echo $this->get_field_name('wid_title'); ?>" type="text" value="<?php echo $wid_title; ?>" />
 		</p>
-		<?php 
+		<?php
 	}
-	
+
 	public function add_remember_me(){
 		$login_afo_rem = get_option('login_afo_rem');
 		if($login_afo_rem == 'Yes'){
-			echo '<li class="remember"><input type="checkbox" name="remember" value="Yes" /> '.__('Remember Me','lwa').'</li>';
+			echo '<p class="remember"><input type="checkbox" name="remember" value="Yes" /> '.__('Remember Me','lwa').'</p>';
 		}
 	}
-	
+
 	public function add_extra_links(){
 		$login_afo_forgot_pass_link = get_option('login_afo_forgot_pass_link');
 		$login_afo_register_link = get_option('login_afo_register_link');
 		if($login_afo_forgot_pass_link or $login_afo_register_link){
-			echo '<li class="extra-links">';
+			echo '<p class="extra-links">';
 		}
 		if($login_afo_forgot_pass_link){
-			echo '<a href="'.get_permalink($login_afo_forgot_pass_link).'">'.__('Lost Password?').'</a>';
+			echo '<a class="lost-password" href="'.get_permalink($login_afo_forgot_pass_link).'">'.__('Lost Password?').'</a>';
 		}
 		if($login_afo_register_link){
-			echo ' <a href="'.get_permalink($login_afo_register_link).'">'.__('Register').'</a>';
+			echo ' <a class="register-link" href="'.get_permalink($login_afo_register_link).'">'.__('Register').'</a>';
 		}
 		if($login_afo_forgot_pass_link or $login_afo_register_link){
-			echo '</li>';
+			echo '</p>';
 		}
 	}
-	
+
 	public function curPageURL() {
 	 $pageURL = 'http';
 	 if (isset($_SERVER["HTTPS"]) and $_SERVER["HTTPS"] == "on") {$pageURL .= "s";}
@@ -86,13 +86,13 @@ class login_wid extends WP_Widget {
 		$redirect_page = get_option('redirect_page');
 		$logout_redirect_page = get_option('logout_redirect_page');
 		$link_in_username = get_option('link_in_username');
-		
+
 		if($redirect_page){
 			$redirect =  get_permalink($redirect_page);
 		} else {
 			$redirect =  $this->curPageURL();
 		}
-		
+
 		if($logout_redirect_page){
 			$logout_redirect_page = get_permalink($logout_redirect_page);
 		} else {
@@ -105,23 +105,29 @@ class login_wid extends WP_Widget {
 		<form name="login" id="login" method="post" action="">
 		<input type="hidden" name="option" value="afo_user_login" />
 		<input type="hidden" name="redirect" value="<?php echo $redirect; ?>" />
-			<ul class="login_wid">
-			<li><?php _e('Username','lwa');?></li>
-			<li><input type="text" name="user_username" required="required"/></li>
-			<li><?php _e('Password','lwa');?></li>
-			<li><input type="password" name="user_password" required="required"/></li>
+			<div class="login_wid">
+				<p class="login_form_group login_wid_username">
+					<label for="user_username"><?php _e('Username','lwa');?></label>
+					<input type="text" name="user_username" required="required" placeholder="Username"/>
+				</p>
+				<p class="login_form_group login_wid_password">
+					<label for="user_username"><?php _e('Password','lwa');?></label>
+					<input type="password" name="user_password" required="required" placeholder="Password"/>
+				</p>
 			<?php $this->add_remember_me();?>
-			<li><input name="login" type="submit" value="<?php _e('Login','lwa');?>" /></li>
+			<p class="login_wid_submit">
+				<button name="login"><?php _e('Login','lwa');?></button>
+			</p>
 			<?php $this->add_extra_links();?>
-			</ul>
+			</div>
 		</form>
-		<?php 
+		<?php
 		} else {
 		global $current_user;
      	get_currentuserinfo();
-		
+
 		if($link_in_username){
-			$link_with_username = '<a href="'.get_permalink($link_in_username).'">'.__('Howdy','lwa').', '.$current_user->display_name.'</a>';
+			$link_with_username = '<a class="link-in-username" href="'.get_permalink($link_in_username).'">'.__('Howdy','lwa').', '.$current_user->display_name.'</a>';
 		} else {
 			$link_with_username = __('Howdy','lwa').', '.$current_user->display_name;
 		}
@@ -129,10 +135,10 @@ class login_wid extends WP_Widget {
 		<ul style="list-style-type:none;">
 			<li><?php echo $link_with_username;?> | <a href="<?php echo wp_logout_url( $logout_redirect_page ); ?>" title="<?php _e('Logout','lwa');?>"><?php _e('Logout','lwa');?></a></li>
 		</ul>
-		<?php 
+		<?php
 		}
 	}
-	
+
 	public function error_message(){
 		if(isset($_SESSION['msg']) and $_SESSION['msg']){
 			echo '<div class="'.$_SESSION['msg_class'].'">'.$_SESSION['msg'].$this->message_close_button().'</div>';
@@ -140,29 +146,29 @@ class login_wid extends WP_Widget {
 			unset($_SESSION['msg_class']);
 		}
 	}
-	
+
 	public function message_close_button(){
 		$cb = '<a href="javascript:void(0);" onclick="closeMessage();" class="close_button_afo">x</a>';
 		return $cb;
 	}
-	
+
 	public function register_plugin_styles() {
 		wp_enqueue_style( 'style_login_widget', plugins_url( 'login-sidebar-widget/style_login_widget.css' ) );
 	}
-	
+
 	public function custom_styles_afo(){
 		echo '<style>';
 			echo stripslashes(get_option('custom_style_afo'));
 		echo '</style>';
 	}
-	
+
 	public function load_script(){?>
 		<script type="text/javascript">
 			function closeMessage(){jQuery('.error_wid_login').hide();}
 		</script>
 	<?php }
-	
-} 
+
+}
 
 function login_validate(){
 	if( isset($_POST['option']) and $_POST['option'] == "afo_user_login"){
@@ -193,7 +199,7 @@ function login_validate(){
 			$_SESSION['msg_class'] = 'error_wid_login';
 			$_SESSION['msg'] = __('Username or password is empty!','lwa');
 		}
-		
+
 	}
 }
 


### PR DESCRIPTION
The login form elements should render with better, more semantic markup to allow integrators and developers to better stylize/manipulate the form. Consider the current markup for a vanilla AFO login form:

`<ul class="login_wid">
  <li>Username</li>
  <li><input type="text" name="user_username" required="required" autocomplete="off"></li>
  <li>Password</li>
  <li><input type="password" name="user_password" required="required" autocomplete="off"></li>
  <li><input name="login" type="submit" value="Login"></li>
</ul>`

The fact that I cannot differentiate between the different list items (and therefore their children elements) makes for a very limited amount of applicable styling/script. As an example, what if I wanted to hide labels and use placeholders instead? Or, what if I wanted to have actual labels that select their respective element on click?

Consider the example following markup (using https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Forms/How_to_structure_an_HTML_form has a guide): 

`<p class="login_form login_form_username">
  <label for="user_username">Username</label>
  <input type="text" name="user_username" required="required" autocomplete="off">
</p><p class="login_form login_form_password">
  <label for="user_password">Password</label>
  <input type="password" name="user_password" required="required" autocomplete="off">
</p><p class="login_form login_form_submit">
  <button>Login</button><p>`

Ah, much better! I now have full styling control over every element, and labels are associated to their respective inputs. Plus, more modern themes have a better chance at instant, near-seamless integration.

I understand due to legacy purposes you may need to keep the list elements, so as to not screw over existing plugin owners that update. But please, start with adding classes to the top-level elements, and associate labels with inputs.
